### PR TITLE
fix: 修復 GetAIResponseAsync 重複用戶訊息問題

### DIFF
--- a/Services/ChatService.cs
+++ b/Services/ChatService.cs
@@ -45,9 +45,6 @@ public class ChatService : IChatService
         {
             _logger.LogInformation("Processing AI response for session {SessionId}", sessionId);
 
-            // Store user message
-            await _chatHistoryService.AddMessageAsync(sessionId, "user", userMessage);
-
             // Search for relevant context from documents
             var relevantContext = await SearchRelevantContextAsync(userMessage, cancellationToken);
 
@@ -64,7 +61,7 @@ public class ChatService : IChatService
                 chatHistory.AddSystemMessage("You are a helpful AI assistant.");
             }
 
-            // Add recent conversation history for context
+            // Add recent conversation history for context (excluding current message)
             var recentMessages = await _chatHistoryService.GetMessagesAsync(sessionId, 10);
             foreach (var message in recentMessages.OrderBy(m => m.Timestamp))
             {
@@ -95,7 +92,8 @@ public class ChatService : IChatService
 
             var aiResponse = response.Content ?? "I apologize, but I couldn't generate a response at this time.";
 
-            // Store AI response
+            // Store user message and AI response after successful generation
+            await _chatHistoryService.AddMessageAsync(sessionId, "user", userMessage);
             await _chatHistoryService.AddMessageAsync(sessionId, "assistant", aiResponse);
 
             _logger.LogInformation("AI response generated successfully for session {SessionId}", sessionId);


### PR DESCRIPTION
## Summary
- 修復 ChatService.GetAIResponseAsync 方法中用戶訊息出現兩次的邏輯錯誤
- 重新調整訊息處理順序，確保對話歷史正確載入 AI context
- 維持完整的錯誤處理和日誌記錄功能

## 問題描述
原本的實作流程存在邏輯錯誤：
1. 先將用戶訊息存入資料庫 (line 49)
2. 檢索歷史訊息時包含了剛存入的訊息 (lines 68-79)
3. 再次手動加入當前用戶訊息 (line 82)

導致當前用戶訊息在發送給 AI 的聊天歷史中出現**兩次**。

## 解決方案
重新調整 `Services/ChatService.cs` 中的訊息處理順序：
1. 檢索歷史對話記錄（不包含當前訊息）
2. 建構完整的聊天歷史並加入當前用戶訊息
3. 生成 AI 回應後再將用戶訊息和 AI 回應一併存入資料庫

## 變更詳情
- **修改檔案**: `Services/ChatService.cs`
- **主要變更**: 將 `AddMessageAsync` 呼叫從方法開始移到 AI 回應生成之後
- **影響範圍**: 僅影響對話歷史的處理邏輯，不影響其他功能

## Test plan
- [x] 驗證對話歷史正確載入到 AI context
- [x] 確認用戶訊息只出現一次
- [x] 測試多輪對話的歷史記錄連續性
- [x] 驗證錯誤處理和日誌記錄正常運作

🤖 Generated with [Claude Code](https://claude.ai/code)